### PR TITLE
added season strength of schedule rankings

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -208,3 +208,52 @@
     </body>
     </html>
 {% endmacro %}
+
+{% macro sos_macro(league_id, current_week, rankings) %}
+    <!DOCTYPE html>
+    <html lang='en'>
+    <head>
+        {{ google_analytics() }}
+        <meta charset='UTF-8'>
+        <title>Season Strength of Schedule</title>
+        <style>
+            table, td, th {
+              border: 1px solid black;
+              text-align: center;
+            }
+
+            table {
+                border-collapse: collapse;
+                width: 60%
+            }
+        </style>
+    </head>
+    <body>
+    <h1>Strength of Schedule</h1>
+    {{ show_menu(league_id) }}
+    <br />
+    <p>This page shows the strength of schedule for each team. This averages the number of possible wins/losses/draws
+        a player's opponent has each week against other teams over the course of the season. Higher average opponent
+        wins means a harder schedule. Probably does not work for leagues with an odd number of teams. </p>
+    <table>
+        <tr>
+            <th>Ranking</th>
+            <th>Team</th>
+            <th>Avg. Opponent Wins</th>
+            <th>Avg. Opponent Losses</th>
+            <th>Avg. Opponent Draws</th>
+        </tr>
+        {% for team in rankings %}
+            <tr>
+                <td>{{ team[0] }}</td>
+                <td>{{ team[1] }}</td>
+                <td>{{ team[2] }}</td>
+                <td>{{ team[3] }}</td>
+                <td>{{ team[4] }}</td>
+            </tr>
+        {% endfor %}
+    </table>
+    <br/><br/>
+    </body>
+    </html>
+{% endmacro %}

--- a/templates/season_sos.html
+++ b/templates/season_sos.html
@@ -1,0 +1,3 @@
+{% from 'macros.html' import sos_macro %}
+
+{{ sos_macro(league_id, current_week, rankings) }}

--- a/templates/tools.html
+++ b/templates/tools.html
@@ -26,6 +26,7 @@ These tools analyze data from the whole season.
     <li><a href = '{{ url_for('season_rankings', leagueId=league_id) }}'>Season Rankings</a><br /></li>
     <li><a href = '{{ url_for('season_matchups', leagueId=league_id) }}'>Season Matchups</a><br /></li>
     <li><a href = '{{ url_for('season_analysis', leagueId=league_id) }}'>Season Further Analysis</a><br /></li>
+    <li><a href = '{{ url_for('season_sos', leagueId=league_id) }}'>Season Strength of Schedule (Takes a long time to load)</a><br /></li>
 </ul>
 </body>
 </html>


### PR DESCRIPTION
Averages each player's weekly opponent's win/loss/draw against other teams over the course of the season to produce a strength of schedule comparison. It has to get the scoreboard and calculate win/loss/draw for each player every week so it takes a while to run.

Finding the specific player h2h matchups just uses that the scoreboard teams matrix already has them paired up in order.

The numbers are probably off for leagues with an odd number of teams, but oh well.